### PR TITLE
Add BDA Xbox ONE Enhanced Controller (20D6:2801), table-driven VID/PID matching

### DIFF
--- a/usbhost/XBOXONE.cpp
+++ b/usbhost/XBOXONE.cpp
@@ -26,6 +26,32 @@
 // #define PRINTREPORT  // Uncomment to print the report send by the Xbox ONE Controller
 
 #include "HardwareSerial.h"
+
+#include <avr/pgmspace.h>
+
+// Lookup table generated from XBOX_SUPPORTED_DEVICE_LIST in XBOXONE.h - edit the
+// list there, not this table. Each entry packs the pair into one word (VID in the
+// high half, PID in the low half) and lives in flash, which we have far more of
+// to spare than SRAM.
+#define XBOX_DEVICE_ENTRY(vid, pid, name) (((uint32_t)(vid) << 16) | (uint32_t)(pid)),
+static const uint32_t XboxSupportedDevices[] PROGMEM = {
+    XBOX_SUPPORTED_DEVICE_LIST(XBOX_DEVICE_ENTRY)};
+#undef XBOX_DEVICE_ENTRY
+
+static const uint8_t XboxSupportedDeviceCount =
+    sizeof(XboxSupportedDevices) / sizeof(XboxSupportedDevices[0]);
+
+bool XBOXONE::VIDPIDOK(uint16_t vid, uint16_t pid) {
+    const uint32_t target = ((uint32_t)vid << 16) | (uint32_t)pid;
+
+    for (uint8_t i = 0; i < XboxSupportedDeviceCount; i++) {
+        if (pgm_read_dword(&XboxSupportedDevices[i]) == target)
+            return true;
+    }
+
+    return false;
+}
+
 XBOXONE::XBOXONE(USB *pUsb, void (*data_cb)(const uint8_t *data, const uint8_t &ndata))
     : pUsb(pUsb),  // pointer to USB class instance - mandatory
       dataCallback(data_cb),

--- a/usbhost/XBOXONE.h
+++ b/usbhost/XBOXONE.h
@@ -35,34 +35,35 @@
 
 #define XBOX_ONE_MAX_ENDPOINTS 3
 
-// PID and VID of the different versions of the controller - see:
+// The controllers this driver binds to, as exact {VID, PID} pairs.
+//
+// To add support for another controller add one XBOX_DEVICE(vid, pid, name) line
+// below; to drop one, delete its line. Nothing else needs to change - the lookup
+// table in XBOXONE.cpp is generated from this list. The name is documentation
+// only and costs no flash.
+//
+// Reference for known devices:
 // https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c
-
-// Official controllers
-#define XBOX_VID1 0x045E       // Microsoft Corporation
-#define XBOX_ONE_PID1 0x02D1   // Microsoft X-Box One pad
-#define XBOX_ONE_PID2 0x02DD   // Microsoft X-Box One pad (Firmware 2015)
-#define XBOX_ONE_PID3 0x02E3   // Microsoft X-Box One Elite pad
-#define XBOX_ONE_PID4 0x02EA   // Microsoft X-Box One S pad
-#define XBOX_ONE_PID13 0x0B0A  // Microsoft X-Box One Adaptive Controller
-#define XBOX_ONE_PID14 0x0B12  // Microsoft X-Box Core Controller
-
-// Unofficial controllers
-#define XBOX_VID2 0x0738  // Mad Catz
-#define XBOX_VID3 0x0E6F  // Afterglow
-#define XBOX_VID4 0x0F0D  // HORIPAD ONE
-#define XBOX_VID5 0x1532  // Razer
-#define XBOX_VID6 0x24C6  // PowerA
-
-#define XBOX_ONE_PID5 \
-    0x4A01  // Mad Catz FightStick TE 2 - might have different mapping for triggers?
-#define XBOX_ONE_PID6 0x0139   // Afterglow Prismatic Wired Controller
-#define XBOX_ONE_PID7 0x0146   // Rock Candy Wired Controller for Xbox One
-#define XBOX_ONE_PID8 0x0067   // HORIPAD ONE
-#define XBOX_ONE_PID9 0x0A03   // Razer Wildcat
-#define XBOX_ONE_PID10 0x541A  // PowerA Xbox One Mini Wired Controller
-#define XBOX_ONE_PID11 0x542A  // Xbox ONE spectra
-#define XBOX_ONE_PID12 0x543A  // PowerA Xbox One wired controller
+#define XBOX_SUPPORTED_DEVICE_LIST(XBOX_DEVICE)                             \
+    /* Official controllers */                                              \
+    XBOX_DEVICE(0x045E, 0x02D1, "Microsoft X-Box One pad")                  \
+    XBOX_DEVICE(0x045E, 0x02DD, "Microsoft X-Box One pad (Firmware 2015)")  \
+    XBOX_DEVICE(0x045E, 0x02E3, "Microsoft X-Box One Elite pad")            \
+    XBOX_DEVICE(0x045E, 0x02EA, "Microsoft X-Box One S pad")                \
+    XBOX_DEVICE(0x045E, 0x0B0A, "Microsoft X-Box One Adaptive Controller")  \
+    XBOX_DEVICE(0x045E, 0x0B12, "Microsoft X-Box Core Controller")          \
+                                                                            \
+    /* Unofficial controllers */                                            \
+    /* NOTE: the FightStick TE 2 may need a different trigger mapping */    \
+    XBOX_DEVICE(0x0738, 0x4A01, "Mad Catz FightStick TE 2")                 \
+    XBOX_DEVICE(0x0E6F, 0x0139, "Afterglow Prismatic Wired Controller")     \
+    XBOX_DEVICE(0x0E6F, 0x0146, "Rock Candy Wired Controller for Xbox One") \
+    XBOX_DEVICE(0x0F0D, 0x0067, "HORIPAD ONE")                              \
+    XBOX_DEVICE(0x1532, 0x0A03, "Razer Wildcat")                            \
+    XBOX_DEVICE(0x24C6, 0x541A, "PowerA Xbox One Mini Wired Controller")    \
+    XBOX_DEVICE(0x24C6, 0x542A, "Xbox ONE spectra")                         \
+    XBOX_DEVICE(0x24C6, 0x543A, "PowerA Xbox One wired controller")         \
+    XBOX_DEVICE(0x20D6, 0x2801, "BDA Xbox ONE Enhanced Controller")
 
 /** This class implements support for a Xbox ONE controller connected via USB. */
 class XBOXONE : public USBDeviceConfig, public UsbConfigXtracter {
@@ -123,15 +124,7 @@ public:
      * @param  pid The device's PID.
      * @return     Returns true if the device's VID and PID matches this driver.
      */
-    virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
-        return ((vid == XBOX_VID1 || vid == XBOX_VID2 || vid == XBOX_VID3 || vid == XBOX_VID4 ||
-                 vid == XBOX_VID5 || vid == XBOX_VID6) &&
-                (pid == XBOX_ONE_PID1 || pid == XBOX_ONE_PID2 || pid == XBOX_ONE_PID3 ||
-                 pid == XBOX_ONE_PID4 || pid == XBOX_ONE_PID5 || pid == XBOX_ONE_PID6 ||
-                 pid == XBOX_ONE_PID7 || pid == XBOX_ONE_PID8 || pid == XBOX_ONE_PID9 ||
-                 pid == XBOX_ONE_PID10 || pid == XBOX_ONE_PID11 || pid == XBOX_ONE_PID12 ||
-                 pid == XBOX_ONE_PID13 || pid == XBOX_ONE_PID14));
-    };
+    virtual bool VIDPIDOK(uint16_t vid, uint16_t pid);
     /**@}*/
 
     /** @name Xbox Controller functions */


### PR DESCRIPTION
## What

Adds support for the **BDA / PowerA Xbox ONE Enhanced Controller** (`20D6:2801`), and replaces the VID/PID `#define` chain with a generated lookup table.

## Adding a controller is now one line

`usbhost/XBOXONE.h`:

```c
XBOX_DEVICE(0x20D6, 0x2801, "BDA Xbox ONE Enhanced Controller")
```

That list is the only place VID/PIDs appear. The table in `XBOXONE.cpp` is generated from it via X-macro, so there is no counter to bump, no `||` chain to extend, and the two cannot drift apart. Names are macro arguments only, never emitted, so they cost no flash.

## Exact pair matching

The previous `VIDPIDOK()` matched *any* listed VID against *any* listed PID — 7 x 15 = 105 accepted combinations, of which only 15 are real devices. It now matches exact `{VID, PID}` pairs.

This is a deliberate narrowing. A device reporting a mix-and-match ID (for example a clone reporting VID `0x0E6F` with PID `0x02D1`) would have bound before and will not now.

## Device identification

`20D6:2801` is absent from `usb.ids`, from Linux `xpad.c`, and from SDL_GameControllerDB. Identified from a real `lsusb` dump in the [linuxhw/LsUSB](https://github.com/linuxhw/LsUSB) corpus:

```
Bus 003 Device 019: ID 20d6:2801 BDA Xbox ONE Enhanced Controller
  iManufacturer    1 BDA
  iProduct         2 Xbox ONE Enhanced Controller
```

It carries the GIP signature the driver targets — `bInterfaceClass 255`, `bInterfaceSubClass 71 (0x47)`, `bInterfaceProtocol 208 (0xD0)` — and exposes interrupt `0x81 IN` / `0x01 OUT` at 64 bytes on interface 0, which is what `EndpointXtract` binds. Its isochronous (headset audio) and bulk interfaces are ignored, as that function early-returns on non-interrupt endpoints.

## Size

| | before | after |
|---|---|---|
| Program | 26542 B (81.0%) | **26484 B (80.8%)** |
| Data | 1428 B (55.8%) | 1428 B (55.8%) |

The table is `PROGMEM` and read with `pgm_read_dword`, so SRAM is untouched and flash drops 58 bytes despite the added device.

## Testing

Builds clean with avr-gcc 15.2.0. The generated table was verified by dumping `XboxSupportedDevices` out of the ELF — all 15 pairs decode correctly.

> [!WARNING]
> **Not tested against physical hardware.** Neither the new device nor the exact-pair narrowing has been confirmed on a real controller.