### PR TITLE
Add Alesis Crimson MIDI mapping and CI builds for every variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  # Enumerate the firmware variants to build: the stock mapping, plus one per
+  # Config/*MidiMapping.tbl. Adding a kit table is all it takes to get a hex.
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      variants: ${{ steps.find.outputs.variants }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: find
+        run: |
+          variants=$(
+            {
+              echo '{"name":"default","map":""}'
+              for f in Config/*.tbl; do
+                base=$(basename "$f")
+                [ "$base" = "DefaultMidiMapping.tbl" ] && continue
+                name=$(echo "$base" \
+                  | sed -e 's/MidiMapping\.tbl$//' -e 's/\([a-z0-9]\)\([A-Z]\)/\1-\2/g' \
+                  | tr '[:upper:]' '[:lower:]')
+                printf '{"name":"%s","map":"%s"}\n' "$name" "$base"
+              done
+            } | jq -sc .
+          )
+          echo "variants=$variants" >> "$GITHUB_OUTPUT"
+          echo "Building variants: $variants"
+
+  build:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJson(needs.discover.outputs.variants) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install AVR toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-avr avr-libc binutils-avr
+
+      - name: Build
+        env:
+          MAP: ${{ matrix.variant.map }}
+        run: |
+          if [ -n "$MAP" ]; then
+            make MIDI_MAP="$MAP"
+          else
+            make
+          fi
+
+      - name: Report size
+        run: avr-size --mcu=atmega32u4 --format=avr adapter_common.elf
+
+      - name: Name the hex
+        env:
+          VARIANT: ${{ matrix.variant.name }}
+        run: cp adapter_common.hex "openrb-drums-$VARIANT.hex"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openrb-drums-${{ matrix.variant.name }}
+          path: openrb-drums-${{ matrix.variant.name }}.hex
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
+  # Reused by release.yml so tagged builds come off the exact same matrix.
+  workflow_call:
 
 jobs:
   # Enumerate the firmware variants to build: the stock mapping, plus one per

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  push:
+    tags: ['*']
+
+permissions:
+  contents: write
+
+jobs:
+  # Same discover + build matrix the CI workflow uses, so a release hex is
+  # built exactly the way a CI hex is.
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Collect hex files
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: openrb-drums-*
+          merge-multiple: true
+
+      - name: List what we are shipping
+        run: ls -la dist
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/*.hex --clobber
+          else
+            gh release create "$TAG" dist/*.hex \
+              --title "$TAG" \
+              --generate-notes
+          fi

--- a/Config/AlesisCrimsonMidiMapping.tbl
+++ b/Config/AlesisCrimsonMidiMapping.tbl
@@ -1,0 +1,48 @@
+#ifndef MIDI_MAP
+#pragma error "AlesisCrimsonMidiMapping.tbl should only be included after MIDI_MAP has been defined"
+#endif
+// MIDI_MAP(midi_note_input, rb_drums_out)
+//
+// Alesis Crimson. This kit reports:
+//   toms   50 / 47 / 43 / 41 (high to low), rims 82 / 80 / 75 / 73
+//   hi-hat 8 for both open and closed, 23 splash, 22 pedal
+//   ride   51 bow / 59 edge / 53 bell, crashes 49 and 57
+//
+// Build with:  make MIDI_MAP=AlesisCrimsonMidiMapping.tbl
+
+// kick
+MIDI_MAP(36, OUT_KICK)
+
+// red pad - snare, centre and rim
+MIDI_MAP(38, OUT_PAD_RED)
+MIDI_MAP(40, OUT_PAD_RED)
+
+// yellow pad - tom 1
+MIDI_MAP(50, OUT_PAD_YELLOW)
+MIDI_MAP(82, OUT_PAD_YELLOW)
+
+// blue pad - tom 2
+MIDI_MAP(47, OUT_PAD_BLUE)
+MIDI_MAP(80, OUT_PAD_BLUE)
+
+// green pad - toms 3 and 4 share the lowest colour
+MIDI_MAP(43, OUT_PAD_GREEN)
+MIDI_MAP(75, OUT_PAD_GREEN)
+MIDI_MAP(41, OUT_PAD_GREEN)
+MIDI_MAP(73, OUT_PAD_GREEN)
+
+// yellow cymbal - hi-hat. This kit sends the same note for open and closed, so
+// the articulation is lost; Rock Band only wants "yellow cymbal" either way.
+// Note 22 (pedal) is deliberately left unmapped - there is no hi-hat pedal
+// output, and mapping it would fire a phantom cymbal hit on every pedal press.
+MIDI_MAP(8, OUT_CYM_YELLOW)
+MIDI_MAP(23, OUT_CYM_YELLOW)
+
+// blue cymbal - ride
+MIDI_MAP(51, OUT_CYM_BLUE)
+MIDI_MAP(59, OUT_CYM_BLUE)
+MIDI_MAP(53, OUT_CYM_BLUE)
+
+// green cymbal - both crashes, as yellow and blue are taken by hi-hat and ride
+MIDI_MAP(49, OUT_CYM_GREEN)
+MIDI_MAP(57, OUT_CYM_GREEN)

--- a/makefile
+++ b/makefile
@@ -40,6 +40,14 @@ CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER $(INCLUDE_DIRS) -D__AVR_ATmega32U4__ -DA
 CPP_FLAGS 	 = -std=c++17 -DUSE_LUFA_CONFIG_HEADER $(INCLUDE_DIRS) -I./ -DARDUINO=100 -D__AVR_ATmega32U4__ -DARDUINO_AVR_LEONARDO
 LD_FLAGS     =
 
+# Optional: build against a custom MIDI mapping table in Config/ instead of
+# DefaultMidiMapping.tbl. Leave unset for the stock mapping.
+#   make MIDI_MAP=MyKitMidiMapping.tbl
+ifdef MIDI_MAP
+CC_FLAGS    += -DCUSTOM_MIDI_MAP='"$(MIDI_MAP)"'
+CPP_FLAGS   += -DCUSTOM_MIDI_MAP='"$(MIDI_MAP)"'
+endif
+
 # Default target
 all:
 


### PR DESCRIPTION
## Alesis Crimson support

Adds `Config/AlesisCrimsonMidiMapping.tbl`. The stock table does not cover this kit:

| Alesis Crimson pad | Note | Under stock mapping |
|---|---|---|
| Tom 1 / Tom 2 / Tom 4 | 50 / 47 / 41 | **dead** |
| All tom rims | 82 / 80 / 75 / 73 | **dead** |
| Hi-hat open + closed | 8 | **dead** |
| Hi-hat pedal | 22 | **fires yellow cymbal** |

That leaves the yellow pad, blue pad and yellow cymbal unreachable — three of the eight outputs — while the pedal produces a phantom cymbal hit on every press.

The new table assigns toms high-to-low across yellow → blue → green with rims following their pads, hi-hat to yellow cymbal, ride to blue, and both crashes to green (yellow and blue being taken). Note 22 is deliberately left unmapped, as there is no hi-hat pedal output to drive.

Two limitations worth recording: the kit sends the same note for open and closed hi-hat, so that articulation is lost (Rock Band only wants "yellow cymbal" either way), and both crashes necessarily collapse to green.

## Selecting a mapping

```
make MIDI_MAP=AlesisCrimsonMidiMapping.tbl
```

Unset, the build is byte-for-byte what it was before — the stock path is untouched.

## CI

`.github/workflows/build.yml` builds every variant and uploads a hex per kit. The matrix is **discovered** from `Config/*.tbl` rather than hardcoded, so adding a kit table is all it takes to get a hex built for it:

```json
[{"name":"default","map":""},{"name":"alesis-crimson","map":"AlesisCrimsonMidiMapping.tbl"}]
```

## Verification

- Mapping confirmed by preprocessing `packet_helpers.cpp` and inspecting the generated switch — all 18 cases expand as intended, note 22 absent.
- Both variants built in an `ubuntu:24.04` container (`gcc-avr 7.3.0`, matching the runner) as well as locally on `gcc-avr 15.2.0`.

| variant | program | data |
|---|---|---|
| default | 26484 B (80.8%) | 1428 B (55.8%) |
| alesis-crimson | 26520 B (80.9%) | 1464 B (57.2%) |

The 36-byte RAM increase is a jump table GCC emits for `outputForNote`, sized to the note *span* rather than the count — the Crimson spans 8–82 against the stock table's 22–59. `.rodata` lives in RAM on AVR, hence the cost.

> [!NOTE]
> The mapping is derived from the kit's published note chart and has **not been confirmed on a physical Alesis Crimson**.